### PR TITLE
Add builder-based XMPP server configuration with user authentication

### DIFF
--- a/app/src/test/java/me/forketyfork/growing/xmpp/DefaultSaslHandlerTest.java
+++ b/app/src/test/java/me/forketyfork/growing/xmpp/DefaultSaslHandlerTest.java
@@ -1,0 +1,63 @@
+package me.forketyfork.growing.xmpp;
+
+import org.junit.jupiter.api.Test;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class DefaultSaslHandlerTest {
+
+    private XMLStreamReader createReader(String payload) throws Exception {
+        String xml = "<auth xmlns='" + XmppServerConfig.NAMESPACE_SASL + "' mechanism='PLAIN'>" + payload + "</auth>";
+        return XMLInputFactory.newFactory().createXMLStreamReader(new StringReader(xml));
+    }
+
+    private XMLStreamWriter createWriter(StringWriter out) throws Exception {
+        return XMLOutputFactory.newFactory().createXMLStreamWriter(out);
+    }
+
+    private ClientContext createContext(XMLStreamWriter writer) {
+        return new ClientContext(ClientState.WAITING_FOR_AUTH, writer, new ConcurrentHashMap<>());
+    }
+
+    @Test
+    public void authenticatesKnownUser() throws Exception {
+        String creds = Base64.getEncoder().encodeToString("\0user\0pass".getBytes());
+        XMLStreamReader reader = createReader(creds);
+        reader.nextTag();
+        StringWriter out = new StringWriter();
+        XMLStreamWriter writer = createWriter(out);
+        ClientContext ctx = createContext(writer);
+        DefaultSaslHandler handler = new DefaultSaslHandler(Map.of("user", "pass"));
+
+        handler.handleSaslAuth(reader, ctx);
+
+        assertEquals(ClientState.AUTHENTICATED_WAITING_FOR_RESTART, ctx.getState());
+        assertTrue(out.toString().contains("<success"));
+    }
+
+    @Test
+    public void rejectsUnknownUser() throws Exception {
+        String creds = Base64.getEncoder().encodeToString("\0user\0wrong".getBytes());
+        XMLStreamReader reader = createReader(creds);
+        reader.nextTag();
+        StringWriter out = new StringWriter();
+        XMLStreamWriter writer = createWriter(out);
+        ClientContext ctx = createContext(writer);
+        DefaultSaslHandler handler = new DefaultSaslHandler(Map.of("user", "pass"));
+
+        handler.handleSaslAuth(reader, ctx);
+
+        assertEquals(ClientState.CLOSED, ctx.getState());
+        assertTrue(out.toString().contains("<failure"));
+    }
+}

--- a/app/src/test/java/me/forketyfork/growing/xmpp/SimpleXmppServer.java
+++ b/app/src/test/java/me/forketyfork/growing/xmpp/SimpleXmppServer.java
@@ -61,7 +61,7 @@ public class SimpleXmppServer {
     public SimpleXmppServer(XmppServerConfig config) {
         this.config = config;
         this.streamHandler = new DefaultStreamHandler(config);
-        this.saslHandler = new DefaultSaslHandler();
+        this.saslHandler = new DefaultSaslHandler(config.userCredentials());
         this.iqHandler = new DefaultIqHandler(config.serverName());
         this.messageHandler = new DefaultMessageHandler();
     }


### PR DESCRIPTION
## Summary
- allow building `XmppServerConfig` via a fluent builder with optional user credentials
- authenticate SASL logins against configured users and fail unauthorized attempts
- use configuration builder in tests and add unit tests for SASL handling

## Testing
- `./gradlew test --tests DefaultSaslHandlerTest`
- `./gradlew test` *(fails: com.objogate.exception.Defect at AuctionSniperEndToEndTest.java:18)*

------
https://chatgpt.com/codex/tasks/task_b_68ac905bd90c8332bde96b3f6112bc1b