### PR TITLE
Fix XML parsing exception in SimpleXmppServer during client disconnect

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -35,6 +35,15 @@ tasks.withType<JavaExec> {
 
 tasks.withType<Test> {
     systemProperty("java.util.logging.config.file", "src/main/resources/logging.properties")
+    
+    testLogging {
+        events("passed", "skipped", "failed", "standardOut", "standardError")
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        showExceptions = true
+        showCauses = true
+        showStackTraces = true
+        showStandardStreams = true
+    }
 }
 
 java {

--- a/app/src/test/java/me/forketyfork/growing/xmpp/SimpleXmppServer.java
+++ b/app/src/test/java/me/forketyfork/growing/xmpp/SimpleXmppServer.java
@@ -239,6 +239,16 @@ public class SimpleXmppServer {
                     }
 
                     try {
+                        if (xmlWriter != null && context != null && context.getState() != ClientState.CLOSED) {
+                            // Properly close XML stream if not already closed
+                            try {
+                                xmlWriter.writeEndElement(); // Close the stream:stream element
+                                xmlWriter.writeEndDocument(); // Close the XML document
+                                xmlWriter.flush();
+                            } catch (XMLStreamException e) {
+                                logger.log(Level.FINE, "Error properly closing XML stream", e);
+                            }
+                        }
                         if (xmlWriter != null) {
                             xmlWriter.close();
                         }


### PR DESCRIPTION
Properly close XML stream elements before closing XMLStreamWriter to prevent "XML document structures must start and end within the same entity" exception. Also added enhanced test logging configuration for better debugging.