### PR TITLE
Fix Swing tests on GitHub Actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,4 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y xvfb
       
     - name: Build with Gradle
-      run: ./gradlew build --warning-mode fail
-      
-    - name: Run tests
-      run: xvfb-run -a ./gradlew test
+      run: xvfb-run -a ./gradlew build --warning-mode fail


### PR DESCRIPTION
Add xvfb virtual display to support GUI tests in headless environment. Tests were failing with HeadlessException due to missing display server.